### PR TITLE
Add initial skeleton per README

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./prisma.sqlite"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # babytable
 Basic self-hosted replacement for nocodb, airtable, etc.
 
+## Install & Run
+
+1. Install dependencies for both the server and client:
+
+   ```bash
+   npm install
+   ```
+
+2. Create the SQLite database and generate the Prisma client:
+
+   ```bash
+   cd server && npx prisma migrate dev --name init && cd ..
+   ```
+
+3. Start the backend and frontend together:
+
+   ```bash
+   npm start
+   ```
+
+   The Express API will run on `http://localhost:3000` and the React UI will be available on `http://localhost:5173`.
+
 
 ## Plan for development
 

--- a/client/components/KanbanView.tsx
+++ b/client/components/KanbanView.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useTables } from '../hooks/useTables';
+
+export default function KanbanView() {
+  const { selectedView } = useTables();
+  const [data, setData] = useState<{ columns: any[]; rows: any[] } | null>(null);
+
+  useEffect(() => {
+    if (!selectedView) return;
+    fetch(`/tables/views/${selectedView.id}/rows`)
+      .then((r) => r.json())
+      .then(setData);
+  }, [selectedView]);
+
+  if (!selectedView) return <div className="p-4">Select a view</div>;
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  const column = data.columns.find((c) => c.id === selectedView.kanbanField);
+  if (!column) return <div className="p-4">Missing kanban field</div>;
+
+  const groups: Record<string, any[]> = {};
+  data.rows.forEach((r) => {
+    const key = r.data[column.id] || 'Unset';
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(r);
+  });
+
+  return (
+    <div className="flex space-x-4 p-4 overflow-auto">
+      {Object.entries(groups).map(([key, rows]) => (
+        <div key={key} className="w-64 bg-gray-100 p-2 rounded">
+          <div className="font-bold mb-2">{key}</div>
+          {rows.map((r) => (
+            <div key={r.id} className="bg-white mb-2 p-2 rounded shadow">
+              {data.columns.map((c) => (
+                c.id !== column.id && <div key={c.id}>{String(r.data[c.id] ?? '')}</div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/client/components/TableList.tsx
+++ b/client/components/TableList.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useTables } from '../hooks/useTables';
+
+export default function TableList() {
+  const { tables, setTables, selectedTable, setSelectedTable } = useTables();
+
+  useEffect(() => {
+    fetch('/tables')
+      .then((r) => r.json())
+      .then(setTables);
+  }, [setTables]);
+
+  return (
+    <div className="p-2 border-r w-48 overflow-y-auto">
+      <div className="flex justify-between items-center mb-2">
+        <span className="font-bold">Tables</span>
+        <button
+          className="border px-1"
+          onClick={async () => {
+            const name = prompt('Table name?');
+            if (!name) return;
+            const res = await fetch('/tables', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name }),
+            });
+            const t = await res.json();
+            setTables([...tables, t]);
+          }}
+        >
+          +
+        </button>
+      </div>
+      <ul>
+        {tables.map((t) => (
+          <li key={t.id}>
+            <button
+              className={`block w-full text-left px-1 rounded ${selectedTable?.id === t.id ? 'bg-blue-100' : ''}`}
+              onClick={() => setSelectedTable(t)}
+            >
+              {t.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/components/TableView.tsx
+++ b/client/components/TableView.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useTables } from '../hooks/useTables';
+
+export default function TableView() {
+  const { selectedView } = useTables();
+  const [data, setData] = useState<{ columns: any[]; rows: any[] } | null>(null);
+
+  useEffect(() => {
+    if (!selectedView) return;
+    fetch(`/tables/views/${selectedView.id}/rows`)
+      .then((r) => r.json())
+      .then(setData);
+  }, [selectedView]);
+
+  if (!selectedView) return <div className="p-4">Select a view</div>;
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 overflow-auto">
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            {data.columns.map((c) => (
+              <th key={c.id} className="border px-2 py-1 bg-gray-100">
+                {c.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.rows.map((r) => (
+            <tr key={r.id}>
+              {data.columns.map((c) => (
+                <td key={c.id} className="border px-2 py-1">
+                  {String(r.data[c.id] ?? '')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/client/components/ViewSidebar.tsx
+++ b/client/components/ViewSidebar.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { useTables } from '../hooks/useTables';
+
+export default function ViewSidebar() {
+  const {
+    selectedTable,
+    selectedView,
+    setSelectedView,
+  } = useTables();
+  const [views, setViews] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!selectedTable) return;
+    fetch(`/tables/${selectedTable.id}/views`)
+      .then((r) => r.json())
+      .then(setViews);
+  }, [selectedTable]);
+
+  if (!selectedTable) return null;
+
+  const grouped: Record<string, any[]> = {};
+  views.forEach((v) => {
+    const folder = v.path || '';
+    if (!grouped[folder]) grouped[folder] = [];
+    grouped[folder].push(v);
+  });
+
+  return (
+    <div className="p-2 border-r w-48 overflow-y-auto">
+      <div className="flex justify-between items-center mb-2">
+        <span className="font-bold">Views</span>
+        <button
+          className="border px-1"
+          onClick={async () => {
+            const name = prompt('View name?');
+            if (!name) return;
+            const res = await fetch(`/tables/${selectedTable.id}/views`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name, type: 'table', path: '' }),
+            });
+            const v = await res.json();
+            setViews([...views, v]);
+          }}
+        >
+          +
+        </button>
+      </div>
+      {Object.entries(grouped).map(([folder, items]) => (
+        <div key={folder} className="mb-2">
+          {folder && <div className="font-semibold">{folder}</div>}
+          <ul>
+            {items.map((v) => (
+              <li key={v.id}>
+                <button
+                  className={`block w-full text-left px-1 rounded ${selectedView?.id === v.id ? 'bg-blue-100' : ''}`}
+                  onClick={() => setSelectedView(v)}
+                >
+                  {v.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/client/hooks/useTables.ts
+++ b/client/hooks/useTables.ts
@@ -1,0 +1,20 @@
+import create from 'zustand';
+
+interface TableState {
+  tables: any[];
+  setTables: (tables: any[]) => void;
+  selectedTable?: any;
+  setSelectedTable: (table: any) => void;
+  selectedView?: any;
+  setSelectedView: (view: any) => void;
+}
+
+export const useTables = create<TableState>((set) => ({
+  tables: [],
+  setTables: (tables) => set({ tables }),
+  selectedTable: undefined,
+  setSelectedTable: (table) => set({ selectedTable: table }),
+  selectedView: undefined,
+  setSelectedView: (view) => set({ selectedView: view }),
+}));
+

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>babytable</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './styles/index.css';
+import TableList from './components/TableList';
+import ViewSidebar from './components/ViewSidebar';
+import TableView from './components/TableView';
+import KanbanView from './components/KanbanView';
+import { useTables } from './hooks/useTables';
+
+function App() {
+  const { selectedView } = useTables();
+  return (
+    <div className="flex h-screen text-sm font-sans">
+      <TableList />
+      <ViewSidebar />
+      <div className="flex-1 overflow-hidden">
+        {selectedView?.type === 'kanban' ? <KanbanView /> : <TableView />}
+      </div>
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "babytable-client",
+  "main": "main.tsx",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.3.9"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.14"
+  }
+}
+

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/styles/tailwind.config.js
+++ b/client/styles/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./**/*.{ts,tsx,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["dom", "es2019"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "babytable",
+  "private": true,
+  "workspaces": ["client", "server"],
+  "scripts": {
+    "start:server": "ts-node server/index.ts",
+    "start:client": "vite --host",
+    "start": "concurrently \"npm run start:server\" \"npm run start:client\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  }
+}
+

--- a/server/controllers/TableController.ts
+++ b/server/controllers/TableController.ts
@@ -1,0 +1,137 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const listTables = () =>
+  prisma.table.findMany({ include: { columns: true, rows: true } });
+
+export const createTable = (name: string) =>
+  prisma.table.create({ data: { name } });
+
+export const getTable = (id: string) =>
+  prisma.table.findUnique({
+    where: { id },
+    include: { columns: true, rows: true, views: true },
+  });
+
+export const deleteTable = (id: string) =>
+  prisma.table.delete({ where: { id } });
+
+export const createColumn = (
+  tableId: string,
+  name: string,
+  type: string,
+  linkedTo?: string,
+  options?: any,
+  order?: number
+) =>
+  prisma.column.create({
+    data: { tableId, name, type, linkedTo, options, order },
+  });
+
+export const updateColumn = (
+  id: string,
+  data: { name?: string; type?: string; linkedTo?: string; options?: any; order?: number }
+) => prisma.column.update({ where: { id }, data });
+
+export const deleteColumn = (id: string) =>
+  prisma.column.delete({ where: { id } });
+
+export const createRow = (tableId: string, data: any) =>
+  prisma.row.create({ data: { tableId, data } });
+
+export const updateRow = (id: string, data: any) =>
+  prisma.row.update({ where: { id }, data: { data } });
+
+export const deleteRow = (id: string) => prisma.row.delete({ where: { id } });
+
+export const createView = (
+  tableId: string,
+  name: string,
+  type: string,
+  path: string,
+  filters?: any,
+  sorts?: any,
+  kanbanField?: string
+) =>
+  prisma.view.create({
+    data: { tableId, name, type, path, filters, sorts, kanbanField },
+  });
+
+export const updateView = (
+  id: string,
+  data: {
+    name?: string;
+    type?: string;
+    path?: string;
+    filters?: any;
+    sorts?: any;
+    kanbanField?: string;
+  }
+) => prisma.view.update({ where: { id }, data });
+
+export const deleteView = (id: string) => prisma.view.delete({ where: { id } });
+
+export const listViews = (tableId: string) =>
+  prisma.view.findMany({ where: { tableId } });
+
+export const getViewRows = async (id: string) => {
+  const view = await prisma.view.findUnique({ where: { id } });
+  if (!view) return null;
+  const table = await prisma.table.findUnique({
+    where: { id: view.tableId },
+    include: { columns: true, rows: true },
+  });
+  if (!table) return null;
+
+  let rows = table.rows.map((r) => ({ ...r, data: { ...r.data } }));
+  const filters = (view.filters as any[]) || [];
+  for (const f of filters) {
+    rows = rows.filter((row) => {
+      const val = row.data[f.columnId];
+      switch (f.operator) {
+        case 'eq':
+        default:
+          return val === f.value;
+      }
+    });
+  }
+  const sorts = (view.sorts as any[]) || [];
+  for (const s of sorts) {
+    rows.sort((a, b) => {
+      const va = a.data[s.columnId];
+      const vb = b.data[s.columnId];
+      if (va === vb) return 0;
+      return s.direction === 'desc' ? (va > vb ? -1 : 1) : va > vb ? 1 : -1;
+    });
+  }
+
+  for (const row of rows) {
+    for (const col of table.columns) {
+      if (col.type === 'formula' && col.options?.formula) {
+        const expr = col.options.formula as string;
+        try {
+          const val = Function('row', `return ${expr}`)(row.data);
+          row.data[col.id] = val;
+        } catch {
+          row.data[col.id] = null;
+        }
+      }
+      if (col.type === 'linked-record') {
+        const value = row.data[col.id];
+        const resolve = async (ref: any) => {
+          const r = await prisma.row.findUnique({ where: { id: ref.rowId } });
+          return r?.data || null;
+        };
+        if (Array.isArray(value)) {
+          row.data[col.id] = await Promise.all(value.map(resolve));
+        } else if (value) {
+          row.data[col.id] = await resolve(value);
+        }
+      }
+    }
+  }
+
+  return { view, columns: table.columns, rows };
+};
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import cors from 'cors';
+import tableRoutes from './routes/tableRoutes';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/tables', tableRoutes);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on port ${port}`));
+

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "babytable-server",
+  "main": "index.ts",
+  "type": "module",
+  "scripts": {
+    "start": "ts-node index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@prisma/client": "^5.8.0",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "prisma": "^5.8.0"
+  }
+}
+

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,48 @@
+// Prisma schema for babytable
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Table {
+  id      String   @id @default(cuid())
+  name    String
+  columns Column[]
+  rows    Row[]
+  views   View[]
+}
+
+model Column {
+  id       String   @id @default(cuid())
+  tableId  String
+  table    Table    @relation(fields: [tableId], references: [id])
+  name     String
+  type     String
+  linkedTo String?
+  options  Json?
+  order    Int
+}
+
+model Row {
+  id      String   @id @default(cuid())
+  tableId String
+  table   Table    @relation(fields: [tableId], references: [id])
+  data    Json
+}
+
+model View {
+  id          String   @id @default(cuid())
+  tableId     String
+  table       Table    @relation(fields: [tableId], references: [id])
+  name        String
+  type        String   // "table" or "kanban"
+  path        String   // folder path like "root/sub"
+  filters     Json?
+  sorts       Json?
+  kanbanField String?
+}

--- a/server/routes/tableRoutes.ts
+++ b/server/routes/tableRoutes.ts
@@ -1,0 +1,113 @@
+import { Router } from 'express';
+import {
+  listTables,
+  createTable,
+  getTable,
+  deleteTable,
+  createColumn,
+  updateColumn,
+  deleteColumn,
+  createRow,
+  updateRow,
+  deleteRow,
+  createView,
+  updateView,
+  deleteView,
+  listViews,
+  getViewRows,
+} from '../controllers/TableController';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const tables = await listTables();
+  res.json(tables);
+});
+
+router.get('/:id', async (req, res) => {
+  const table = await getTable(req.params.id);
+  if (!table) return res.status(404).end();
+  res.json(table);
+});
+
+router.post('/', async (req, res) => {
+  const { name } = req.body;
+  const table = await createTable(name);
+  res.json(table);
+});
+
+router.delete('/:id', async (req, res) => {
+  await deleteTable(req.params.id);
+  res.json({});
+});
+
+router.post('/:id/columns', async (req, res) => {
+  const { id } = req.params;
+  const { name, type, linkedTo, options, order } = req.body;
+  const column = await createColumn(id, name, type, linkedTo, options, order);
+  res.json(column);
+});
+
+router.put('/columns/:id', async (req, res) => {
+  const column = await updateColumn(req.params.id, req.body);
+  res.json(column);
+});
+
+router.delete('/columns/:id', async (req, res) => {
+  await deleteColumn(req.params.id);
+  res.json({});
+});
+
+router.post('/:id/rows', async (req, res) => {
+  const { id } = req.params;
+  const { data } = req.body;
+  const row = await createRow(id, data);
+  res.json(row);
+});
+
+router.get('/:id/views', async (req, res) => {
+  const views = await listViews(req.params.id);
+  res.json(views);
+});
+
+router.post('/:id/views', async (req, res) => {
+  const { name, type, path, filters, sorts, kanbanField } = req.body;
+  const view = await createView(
+    req.params.id,
+    name,
+    type,
+    path,
+    filters,
+    sorts,
+    kanbanField
+  );
+  res.json(view);
+});
+
+router.get('/views/:id/rows', async (req, res) => {
+  const data = await getViewRows(req.params.id);
+  if (!data) return res.status(404).end();
+  res.json(data);
+});
+
+router.put('/views/:id', async (req, res) => {
+  const view = await updateView(req.params.id, req.body);
+  res.json(view);
+});
+
+router.delete('/views/:id', async (req, res) => {
+  await deleteView(req.params.id);
+  res.json({});
+});
+
+router.put('/rows/:id', async (req, res) => {
+  const row = await updateRow(req.params.id, req.body.data);
+  res.json(row);
+});
+
+router.delete('/rows/:id', async (req, res) => {
+  await deleteRow(req.params.id);
+  res.json({});
+});
+
+export default router;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold Node server with Express and Prisma
- define Prisma schema for tables, columns and rows
- add basic controller and routes
- create minimal React client with Zustand store
- include Tailwind config and package.json workspaces

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685332717b94832fbc53f09d45e20c5f