### PR TITLE
Fix JSON support for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ model Column {
   name      String
   type      String   // e.g., "text", "number", "linked-record", etc.
   linkedTo  String?  // If type is "linked-record", this is the linked Table ID
-  options   Json?    // for other column types
+  options   String?  // JSON string for other column types
   order     Int
 }
 
@@ -129,7 +129,7 @@ model Row {
   id        String   @id @default(cuid()) // This is the universal identifier
   tableId   String
   table     Table    @relation(fields: [tableId], references: [id])
-  data      Json     // columnId → value (text, number, or array of linked row ids)
+  data      String   // JSON string: columnId → value
 }
 ```
 

--- a/server/controllers/TableController.ts
+++ b/server/controllers/TableController.ts
@@ -1,18 +1,48 @@
 import { PrismaClient } from '@prisma/client';
 
+const parseColumn = (col: any) => ({
+  ...col,
+  options: col.options ? JSON.parse(col.options) : null,
+});
+
+const parseRow = (row: any) => ({
+  ...row,
+  data: row.data ? JSON.parse(row.data) : {},
+});
+
+const parseView = (view: any) => ({
+  ...view,
+  filters: view.filters ? JSON.parse(view.filters) : null,
+  sorts: view.sorts ? JSON.parse(view.sorts) : null,
+});
+
 const prisma = new PrismaClient();
 
-export const listTables = () =>
-  prisma.table.findMany({ include: { columns: true, rows: true } });
+export const listTables = async () => {
+  const tables = await prisma.table.findMany({ include: { columns: true, rows: true } });
+  return tables.map((t) => ({
+    ...t,
+    columns: t.columns.map(parseColumn),
+    rows: t.rows.map(parseRow),
+  }));
+};
 
 export const createTable = (name: string) =>
   prisma.table.create({ data: { name } });
 
-export const getTable = (id: string) =>
-  prisma.table.findUnique({
+export const getTable = async (id: string) => {
+  const table = await prisma.table.findUnique({
     where: { id },
     include: { columns: true, rows: true, views: true },
   });
+  if (!table) return null;
+  return {
+    ...table,
+    columns: table.columns.map(parseColumn),
+    rows: table.rows.map(parseRow),
+    views: table.views.map(parseView),
+  };
+};
 
 export const deleteTable = (id: string) =>
   prisma.table.delete({ where: { id } });
@@ -25,23 +55,45 @@ export const createColumn = (
   options?: any,
   order?: number
 ) =>
-  prisma.column.create({
-    data: { tableId, name, type, linkedTo, options, order },
-  });
+  prisma.column
+    .create({
+      data: {
+        tableId,
+        name,
+        type,
+        linkedTo,
+        options: options ? JSON.stringify(options) : undefined,
+        order,
+      },
+    })
+    .then(parseColumn);
 
 export const updateColumn = (
   id: string,
   data: { name?: string; type?: string; linkedTo?: string; options?: any; order?: number }
-) => prisma.column.update({ where: { id }, data });
+) =>
+  prisma.column
+    .update({
+      where: { id },
+      data: {
+        ...data,
+        options: data.options ? JSON.stringify(data.options) : undefined,
+      },
+    })
+    .then(parseColumn);
 
 export const deleteColumn = (id: string) =>
   prisma.column.delete({ where: { id } });
 
 export const createRow = (tableId: string, data: any) =>
-  prisma.row.create({ data: { tableId, data } });
+  prisma.row
+    .create({ data: { tableId, data: JSON.stringify(data) } })
+    .then(parseRow);
 
 export const updateRow = (id: string, data: any) =>
-  prisma.row.update({ where: { id }, data: { data } });
+  prisma.row
+    .update({ where: { id }, data: { data: JSON.stringify(data) } })
+    .then(parseRow);
 
 export const deleteRow = (id: string) => prisma.row.delete({ where: { id } });
 
@@ -54,9 +106,19 @@ export const createView = (
   sorts?: any,
   kanbanField?: string
 ) =>
-  prisma.view.create({
-    data: { tableId, name, type, path, filters, sorts, kanbanField },
-  });
+  prisma.view
+    .create({
+      data: {
+        tableId,
+        name,
+        type,
+        path,
+        filters: filters ? JSON.stringify(filters) : undefined,
+        sorts: sorts ? JSON.stringify(sorts) : undefined,
+        kanbanField,
+      },
+    })
+    .then(parseView);
 
 export const updateView = (
   id: string,
@@ -68,23 +130,37 @@ export const updateView = (
     sorts?: any;
     kanbanField?: string;
   }
-) => prisma.view.update({ where: { id }, data });
+) =>
+  prisma.view
+    .update({
+      where: { id },
+      data: {
+        ...data,
+        filters: data.filters ? JSON.stringify(data.filters) : undefined,
+        sorts: data.sorts ? JSON.stringify(data.sorts) : undefined,
+      },
+    })
+    .then(parseView);
 
 export const deleteView = (id: string) => prisma.view.delete({ where: { id } });
 
 export const listViews = (tableId: string) =>
-  prisma.view.findMany({ where: { tableId } });
+  prisma.view
+    .findMany({ where: { tableId } })
+    .then((views) => views.map(parseView));
 
 export const getViewRows = async (id: string) => {
-  const view = await prisma.view.findUnique({ where: { id } });
-  if (!view) return null;
+  const viewRecord = await prisma.view.findUnique({ where: { id } });
+  if (!viewRecord) return null;
   const table = await prisma.table.findUnique({
-    where: { id: view.tableId },
+    where: { id: viewRecord.tableId },
     include: { columns: true, rows: true },
   });
   if (!table) return null;
 
-  let rows = table.rows.map((r) => ({ ...r, data: { ...r.data } }));
+  const view = parseView(viewRecord);
+  const columns = table.columns.map(parseColumn);
+  let rows = table.rows.map(parseRow);
   const filters = (view.filters as any[]) || [];
   for (const f of filters) {
     rows = rows.filter((row) => {
@@ -107,7 +183,7 @@ export const getViewRows = async (id: string) => {
   }
 
   for (const row of rows) {
-    for (const col of table.columns) {
+    for (const col of columns) {
       if (col.type === 'formula' && col.options?.formula) {
         const expr = col.options.formula as string;
         try {
@@ -132,6 +208,6 @@ export const getViewRows = async (id: string) => {
     }
   }
 
-  return { view, columns: table.columns, rows };
+  return { view, columns, rows };
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import tableRoutes from './routes/tableRoutes';
+import tableRoutes from './routes/tableRoutes.ts';
 
 const app = express();
 app.use(cors());

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Column {
   name     String
   type     String
   linkedTo String?
-  options  Json?
+  options  String?
   order    Int
 }
 
@@ -32,7 +32,7 @@ model Row {
   id      String   @id @default(cuid())
   tableId String
   table   Table    @relation(fields: [tableId], references: [id])
-  data    Json
+  data    String
 }
 
 model View {
@@ -42,7 +42,7 @@ model View {
   name        String
   type        String   // "table" or "kanban"
   path        String   // folder path like "root/sub"
-  filters     Json?
-  sorts       Json?
+  filters     String?
+  sorts       String?
   kanbanField String?
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "allowImportingTsExtensions": true
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- store JSON as strings to make Prisma work with SQLite
- parse and stringify JSON fields in controller
- adjust ESM import paths
- allow importing `.ts` extensions
- update docs for JSON string workaround

## Testing
- `npx --no-install tsc -p server/tsconfig.json` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_685338680d94832fb3c90a184f43537d