### PR TITLE
Fix import path for TableController

### DIFF
--- a/server/routes/tableRoutes.ts
+++ b/server/routes/tableRoutes.ts
@@ -15,7 +15,7 @@ import {
   deleteView,
   listViews,
   getViewRows,
-} from '../controllers/TableController';
+} from '../controllers/TableController.ts';
 
 const router = Router();
 


### PR DESCRIPTION
## Summary
- include `.ts` extension when importing `TableController`

## Testing
- `npm start` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_685339cdc1a0832fa5501e7de0fa542d