### PR TITLE
Fix Vite root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Basic self-hosted replacement for nocodb, airtable, etc.
    npm start
    ```
 
-   The Express API will run on `http://localhost:3000` and the React UI will be available on `http://localhost:5173`.
+   The Express API will run on `http://localhost:3000` and the React UI will be
+   served from the `client` directory at `http://localhost:5173`.
 
 
 ## Plan for development

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": ["client", "server"],
   "scripts": {
     "start:server": "ts-node server/index.ts",
-    "start:client": "vite --host",
+    "start:client": "vite --host --root client",
     "start": "concurrently \"npm run start:server\" \"npm run start:client\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- point Vite at the `client` directory so it can load index.html
- clarify in the README that the React UI is served from `client`

## Testing
- `npm start` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533ddff414832f84661ba3ef4b08f4